### PR TITLE
Add integration with Extra Machine Config's per-recipe fuels.

### DIFF
--- a/Junimatic/IExtraMachineConfigApi.cs
+++ b/Junimatic/IExtraMachineConfigApi.cs
@@ -1,0 +1,16 @@
+using StardewValley.GameData.Machines;
+using System.Collections.Generic;
+
+namespace NermNermNerm.Junimatic;
+
+/// <summary>The API provided by the Extra Machine Config mod.</summary>
+public interface IExtraMachineConfigApi
+{
+    /// <summary>Retrieves the extra fuels consumed by this recipe.</summary>
+    /// <param name="outputData">The output rule to check.</param>
+    IList<(string, int)> GetExtraRequirements(MachineItemOutput outputData);
+
+    /// <summary>Retrieves the extra tag-defined fuels consumed by this recipe.</summary>
+    /// <param name="outputData">The output rule to check.</param>
+    IList<(string, int)> GetExtraTagsRequirements(MachineItemOutput outputData);
+}

--- a/Junimatic/ModEntry.cs
+++ b/Junimatic/ModEntry.cs
@@ -66,6 +66,8 @@ namespace NermNermNerm.Junimatic
 
         public bool IsRunningSve => this.Helper.ModRegistry.IsLoaded("FlashShifter.SVECode");
 
+        public IExtraMachineConfigApi? ExtraMachineConfigApi => this.Helper.ModRegistry.GetApi<IExtraMachineConfigApi>("selph.ExtraMachineConfig");
+
         private void SetJunimoColor(Event @event, string[] split, EventContext context)
         {
             try

--- a/Junimatic/ObjectMachine.cs
+++ b/Junimatic/ObjectMachine.cs
@@ -72,7 +72,8 @@ namespace NermNermNerm.Junimatic
 
             // Extra Machine Config applies some extra logic to game functions that relies on autoLoadFrom being set to the appropriate inventory.
             var oldAutoLoadFrom = StardewValley.Object.autoLoadFrom;
-            try {
+            try
+            {
                 StardewValley.Object.autoLoadFrom = sourceInventory;
                 foreach (var item in sourceInventory)
                 {

--- a/Junimatic/ObjectMachine.cs
+++ b/Junimatic/ObjectMachine.cs
@@ -77,7 +77,7 @@ namespace NermNermNerm.Junimatic
             {
                 if (MachineDataUtility.TryGetMachineOutputRule(this.Machine, machineData, MachineOutputTrigger.ItemPlacedInMachine, item, Game1.MasterPlayer, this.Machine.Location, out var rule, out var triggerRule, out var ruleIgnoringCount, out var triggerIgnoringCount))
                 {
-                    var machineItemOutput = rule.OutputItem.FirstOrDefault(machineItemOutput => MachineDataUtility.GetOutputItem(this.Machine, machineItemOutput, item, Game1.MasterPlayer, true, out int? overrideMinutesUntilReady) is not null, null);
+                    var machineItemOutput = MachineDataUtility.GetOutputData(this.Machine, machineData, rule, item, Game1.MasterPlayer, this.Machine.Location);
                     if (machineItemOutput is not null)
                     {
 
@@ -88,7 +88,7 @@ namespace NermNermNerm.Junimatic
                         {
                             foreach ((string extraItemId, int extraCount) in extraMachineConfigApi.GetExtraRequirements(machineItemOutput))
                             {
-                                var matchingItem = sourceInventory.First(item => CraftingRecipe.ItemMatchesForCrafting(item, extraItemId));
+                                var matchingItem = sourceInventory.FirstOrDefault(item => CraftingRecipe.ItemMatchesForCrafting(item, extraItemId), null);
                                 if (matchingItem != null)
                                 {
                                     var itemToAdd = matchingItem.getOne();
@@ -98,7 +98,7 @@ namespace NermNermNerm.Junimatic
                             }
 
                             foreach ((string extraContextTags, int extraCount) in extraMachineConfigApi.GetExtraTagsRequirements(machineItemOutput)) {
-                                var matchingItem = sourceInventory.First(item => ItemContextTagManager.DoesTagQueryMatch(extraContextTags, item.GetContextTags()));
+                                var matchingItem = sourceInventory.FirstOrDefault(item => ItemContextTagManager.DoesTagQueryMatch(extraContextTags, item?.GetContextTags() ?? new HashSet<string>()), null);
                                 if (matchingItem != null)
                                 {
                                     var itemToAdd = matchingItem.getOne();

--- a/Junimatic/ObjectMachine.cs
+++ b/Junimatic/ObjectMachine.cs
@@ -78,7 +78,7 @@ namespace NermNermNerm.Junimatic
                 if (MachineDataUtility.TryGetMachineOutputRule(this.Machine, machineData, MachineOutputTrigger.ItemPlacedInMachine, item, Game1.MasterPlayer, this.Machine.Location, out var rule, out var triggerRule, out var ruleIgnoringCount, out var triggerIgnoringCount))
                 {
                     var machineItemOutput = MachineDataUtility.GetOutputData(this.Machine, machineData, rule, item, Game1.MasterPlayer, this.Machine.Location);
-                    if (machineItemOutput is not null)
+                    if (machineItemOutput is not null && MachineDataUtility.GetOutputItem(this.Machine, machineItemOutput, item, Game1.MasterPlayer, true, out int? overrideMinutesUntilReady) is not null)
                     {
 
                         // Add extra fuels from EMC if applicable, making sure to insert them before the primary input


### PR DESCRIPTION
Link to EMC's [Nexus page](https://www.nexusmods.com/stardewvalley/mods/22256) and [GitHub repo](https://github.com/zombifier/My_Stardew_Mods/tree/master/ExtraMachineConfig#adding-additional-fuel-for-a-specific-recipe).

What this does:

- Sets `StardewValley.Object.autoLoadFrom` to the inventory being checked (and unset it upon exiting the function) since EMC's patches on the base game functions that checks whether a machine output rule is valid assumes they're being called within the context of player hand feeding or hopper/Automate autoloading, which sets that field accordingly in the latter case.
- Calls EMC's API to retrieve the extra fuels and adds them to the list of items a Junimo must bring to a machine.
- Changes the method of retrieving `machineItemOutput` from testing all of them with `GetOutputItem` to simply calling `GetOutputData` and then `GetOutputItem`. This is not directly related to EMC, but it brings the logic to be inline with the game's own `OutputMachine` function, and improves compat in the case of multiple output rules where not all of them are deemed valid by EMC.

Tested with [Cornucopia Artisan Machines](https://www.nexusmods.com/stardewvalley/mods/24842), particularly with its rules for the mayo machines that use eggs as additional fuel instead of the primary input. Put a Cornucopia Peppercorn (in the first slot) and some eggs inside an input chest; before this PR, the peppercorn is ignored and the eggs are loaded to make plain mayo; after this PR, the Junimo should take the peppercorn and an egg to make peppercorn mayo.