### PR TITLE
Let users choose to preserve items

### DIFF
--- a/Junimatic/CrabPotMachine.cs
+++ b/Junimatic/CrabPotMachine.cs
@@ -25,7 +25,7 @@ namespace NermNermNerm.Junimatic
 
         public override bool IsIdle => this.Machine.heldObject.Value is null && this.Machine.bait.Value is null;
 
-        public override List<Item>? GetRecipeFromChest(GameStorage storage)
+        public override List<Item>? GetRecipeFromChest(GameStorage storage, Func<Item, bool> isShinyTest)
         {
             // TODO? Crab pots have the notion of an owner and the owner may or may not have the profession that
             //  makes it so that the traps don't need bait.  This ignores that.  Perhaps it's actually by-design
@@ -57,9 +57,9 @@ namespace NermNermNerm.Junimatic
             return oldHeldObject;
         }
 
-        public override bool FillMachineFromChest(GameStorage storage)
+        public override bool FillMachineFromChest(GameStorage storage, Func<Item, bool> isShinyTest)
         {
-            if (!base.FillMachineFromChest(storage))
+            if (!base.FillMachineFromChest(storage, isShinyTest))
             {
                 return false;
             }

--- a/Junimatic/FishPondMachine.cs
+++ b/Junimatic/FishPondMachine.cs
@@ -18,7 +18,7 @@ namespace NermNermNerm.Junimatic
 
         public override bool IsIdle => false;
 
-        public override bool FillMachineFromChest(GameStorage storage)
+        public override bool FillMachineFromChest(GameStorage storage, Func<Item,bool> isShinyTest)
         {
             // IsIdle being hard-coded to false should prevent this from being called.
             throw new NotImplementedException();
@@ -30,7 +30,7 @@ namespace NermNermNerm.Junimatic
             throw new NotImplementedException();
         }
 
-        public override List<Item>? GetRecipeFromChest(GameStorage storage)
+        public override List<Item>? GetRecipeFromChest(GameStorage storage, Func<Item, bool> isShinyTest)
         {
             // IsIdle being hard-coded to false should prevent this from being called.
             throw new NotImplementedException();

--- a/Junimatic/GameMachine.cs
+++ b/Junimatic/GameMachine.cs
@@ -1,11 +1,8 @@
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Xna.Framework;
 using StardewValley;
-using StardewValley.GameData.Machines;
 using StardewValley.Inventories;
-using StardewValley.Objects;
-using StardewValley.TerrainFeatures;
 
 namespace NermNermNerm.Junimatic
 {
@@ -23,12 +20,12 @@ namespace NermNermNerm.Junimatic
         /// </summary>
         public abstract bool IsIdle { get; }
 
-        public abstract Object? HeldObject { get; }
+        public abstract StardewValley.Object? HeldObject { get; }
 
         /// <summary>
         ///   Returns the HeldObject and removes it from the machines.
         /// </summary>
-        public Object RemoveHeldObject()
+        public StardewValley.Object RemoveHeldObject()
         {
             return this.TakeItemFromMachine();
         }
@@ -53,13 +50,13 @@ namespace NermNermNerm.Junimatic
         ///   enough stuff in the chest to allow it, it builds a list of the items needed but doesn't
         ///   actually remove the items from the chest.
         /// </summary>
-        public abstract List<Item>? GetRecipeFromChest(GameStorage storage);
+        public abstract List<Item>? GetRecipeFromChest(GameStorage storage, Func<Item, bool> isShinyTest);
 
         /// <summary>
         ///   Tries to populate the given machine's input with the contents of the chest.  If it
         ///   succeeds, it returns true and the necessary items are removed.
         /// </summary>
-        public abstract bool FillMachineFromChest(GameStorage storage);
+        public abstract bool FillMachineFromChest(GameStorage storage, Func<Item,bool> isShinyTest);
 
         /// <summary>
         ///   Fills the machine from the supplied Junimo inventory.

--- a/Junimatic/GameStorage.cs
+++ b/Junimatic/GameStorage.cs
@@ -140,11 +140,11 @@ namespace NermNermNerm.Junimatic
 
         /// <summary>
         ///   Given a list of items and quantities, <paramref name="shoppingList"/>, first see if the chest actually contains that much stuff
-        ///   and then transfers the items from the chest into <paramref name="totebag"/>.
+        ///   and then transfers the items from the chest into <paramref name="toteBag"/>.
         /// </summary>
-        /// <returns>True if all the items in <paramref name="shoppingList"/> were transferred to <paramref name="totebag"/>, false if
+        /// <returns>True if all the items in <paramref name="shoppingList"/> were transferred to <paramref name="toteBag"/>, false if
         /// the chest didn't contain all the things on the list</returns>
-        public bool TryFulfillShoppingList(List<Item> shoppingList, Inventory totebag)
+        public bool TryFulfillShoppingList(List<Item> shoppingList, Inventory toteBag)
         {
             // Ensure enough stuff exists
             var chestInventory = this.RawInventory;
@@ -163,7 +163,7 @@ namespace NermNermNerm.Junimatic
                 Item template = null!; // The while loop is guaranteed to be run once because leftToRemove will always be > 1
                 while (leftToRemove > 0)
                 {
-                    var first = chestInventory.First(i => i is not null && i.Stack > 0 && i.ItemId == item.ItemId);
+                    var first = chestInventory.First(i => i is not null && i.Stack > 0 && i.ItemId == item.ItemId && i.Quality == item.Quality);
                     if (first.Stack > item.Stack)
                     {
                         first.Stack -= leftToRemove;
@@ -182,7 +182,7 @@ namespace NermNermNerm.Junimatic
                 //   such machines (stock).  I suspect if there were such machines, they'd be have the same problem.
                 var newItem = ItemRegistry.Create<StardewValley.Object>(template.QualifiedItemId, item.Stack, template.Quality);
                 newItem.preservedParentSheetIndex.Value = ((StardewValley.Object)template).preservedParentSheetIndex.Value;
-                totebag.Add(newItem);
+                toteBag.Add(newItem);
             }
 
             return true;

--- a/Junimatic/JunimoShuffler.cs
+++ b/Junimatic/JunimoShuffler.cs
@@ -166,10 +166,10 @@ namespace NermNermNerm.Junimatic
                     return;
                 }
 
-                l.playSound("dwop"); // <- might get overriden by the furnace sound...  but if it's not a furnace...
+                l.playSound("dwop"); // <- might get overridden by the furnace sound...  but if it's not a furnace...
             }
 
-            var newAssignment = (new WorkFinder()).FindProject(this.Assignment.hut, this.Assignment.projectType, this);
+            var newAssignment = this.workFinder!.FindProject(this.Assignment.hut, this.Assignment.projectType, this);
             if (newAssignment is not null)
             {
                 this.Assignment = newAssignment;

--- a/Junimatic/JunimoStatus.cs
+++ b/Junimatic/JunimoStatus.cs
@@ -8,15 +8,16 @@ using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.Linq;
 
-using static NermNermNerm.Stardew.LocalizeFromSource.SdvLocalize;
 using Microsoft.Xna.Framework.Graphics;
 using StardewValley.TerrainFeatures;
+
+using static NermNermNerm.Stardew.LocalizeFromSource.SdvLocalize;
 
 namespace NermNermNerm.Junimatic
 {
     public class JunimoStatus : ModLet
     {
-        public const int NumShinySlots = 10;
+        public const int NumShinySlots = 12;
 
         public const string UpdateListMessageId = "Junimatic.ShinyList";
         public const string AskForListMessageId = "Junimatic.PleaseSendList";
@@ -104,7 +105,7 @@ namespace NermNermNerm.Junimatic
             }
         }
 
-        private List<Item> LoadShinyThings()
+        public List<Item> LoadShinyThings()
         {
             Game1.CustomData.TryGetValue("Junimatic.ShinyThings", out string? serialized);
             return this.DeserializeShinyList(serialized ?? "");
@@ -150,7 +151,7 @@ namespace NermNermNerm.Junimatic
             return serialized.ToString();
         }
 
-        private void OnPlayerChangedShinyList(IEnumerable<Item> shinyThings)
+        public void OnPlayerChangedShinyList(IEnumerable<Item> shinyThings)
         {
             string serialized = this.SerializeShinyList(shinyThings);
             this.SendState(serialized);
@@ -160,6 +161,7 @@ namespace NermNermNerm.Junimatic
             }
         }
 
+#if false
         private class JunimoStatusMenu : StorageContainer
         {
             private readonly JunimoStatus owner;
@@ -167,12 +169,17 @@ namespace NermNermNerm.Junimatic
             public JunimoStatusMenu(JunimoStatus owner)
                 : base(FluffUpList(Game1.IsMasterGame ? owner.LoadShinyThings() : new List<Item>()),
                       NumShinySlots,
-                      2,
+                      1, // number of rows of shiny stuff inventory
                       (i, p, o, c, ir) => ((JunimoStatusMenu)c).OnChangingShinyItems(i, p, o, c, ir),
                       Utility.highlightSmallObjects)
             {
                 this.owner = owner;
-                this.ItemsToGrabMenu.descriptionText = I("yowsa yow yow yow!");
+
+                // This code controls where it goes - because reasons, it's not actually quite correct
+                //int num = 64 * (capacity / rows);
+                //ItemsToGrabMenu = new InventoryMenu(Game1.uiViewport.Width / 2 - num / 2, yPositionOnScreen + 64, playerInventory: false, inventory, null, capacity, rows);
+                this.ItemsToGrabMenu.xPositionOnScreen = this.inventory.xPositionOnScreen;
+                this.ItemsToGrabMenu.yPositionOnScreen = this.yPositionOnScreen + 192;
             }
 
             public void Reset(List<Item> newItems)
@@ -268,20 +275,31 @@ namespace NermNermNerm.Junimatic
 
                 // ..except for this call to MenuWithInventory.draw
                 // base.draw(b, drawUpperPortion: false, drawDescriptionArea: false);
-                int red = -1, green = -1, blue = -1;
-                // Copied from 
                 if (this.trashCan != null)
                 {
                     this.trashCan.draw(b);
                     b.Draw(Game1.mouseCursors, new Vector2(this.trashCan.bounds.X + 60, this.trashCan.bounds.Y + 40), new Rectangle(564 + Game1.player.trashCanLevel * 18, 129, 18, 10), Color.White, this.trashCanLidRotation, new Vector2(16f, 10f), 4f, SpriteEffects.None, 0.86f);
                 }
-                Game1.drawDialogueBox(this.xPositionOnScreen - IClickableMenu.borderWidth / 2, this.yPositionOnScreen + IClickableMenu.borderWidth + IClickableMenu.spaceToClearTopBorder + 64, this.width, this.height - (IClickableMenu.borderWidth + IClickableMenu.spaceToClearTopBorder + 192), speaker: false, drawOnlyBox: true);
+                // Draw the box around the player's inventory
+                Game1.drawDialogueBox(
+                    x: this.xPositionOnScreen - IClickableMenu.borderWidth / 2,
+                    y: this.yPositionOnScreen + IClickableMenu.borderWidth + IClickableMenu.spaceToClearTopBorder + 64,
+                    width: this.width,
+                    height: this.height - (IClickableMenu.borderWidth + IClickableMenu.spaceToClearTopBorder + 192),
+                    speaker: false,
+                    drawOnlyBox: true);
                 this.okButton?.draw(b);
-                this.inventory.draw(b, red, green, blue);
+                this.inventory.draw(b, red: -1, green: -1, blue: -1); // Draw the actual inventory
                 // end MenuWithInventory.draw
-                
 
-                Game1.drawDialogueBox(this.ItemsToGrabMenu.xPositionOnScreen - IClickableMenu.borderWidth - IClickableMenu.spaceToClearSideBorder, ItemsToGrabMenu.yPositionOnScreen - IClickableMenu.borderWidth - IClickableMenu.spaceToClearTopBorder, ItemsToGrabMenu.width + IClickableMenu.borderWidth * 2 + IClickableMenu.spaceToClearSideBorder * 2, ItemsToGrabMenu.height + IClickableMenu.spaceToClearTopBorder + IClickableMenu.borderWidth * 2, speaker: false, drawOnlyBox: true);
+
+                Game1.drawDialogueBox(
+                    x: this.ItemsToGrabMenu.xPositionOnScreen - IClickableMenu.borderWidth - IClickableMenu.spaceToClearSideBorder,
+                    y: this.ItemsToGrabMenu.yPositionOnScreen - IClickableMenu.borderWidth - IClickableMenu.spaceToClearTopBorder,
+                    width: this.ItemsToGrabMenu.width + IClickableMenu.borderWidth * 2 + IClickableMenu.spaceToClearSideBorder * 2,
+                    height: this.ItemsToGrabMenu.height + IClickableMenu.spaceToClearTopBorder + IClickableMenu.borderWidth * 2,
+                    speaker: false,
+                    drawOnlyBox: true);
                 this.ItemsToGrabMenu.draw(b);
                 // this.poof?.draw(b, localPosition: true);
                 if (!this.hoverText.Equals(""))
@@ -298,5 +316,6 @@ namespace NermNermNerm.Junimatic
                 }
             }
         }
+#endif
     }
 }

--- a/Junimatic/JunimoStatus.cs
+++ b/Junimatic/JunimoStatus.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Linq;
 
 using static NermNermNerm.Stardew.LocalizeFromSource.SdvLocalize;
+using Microsoft.Xna.Framework.Graphics;
+using StardewValley.TerrainFeatures;
 
 namespace NermNermNerm.Junimatic
 {
@@ -170,6 +172,7 @@ namespace NermNermNerm.Junimatic
                       Utility.highlightSmallObjects)
             {
                 this.owner = owner;
+                this.ItemsToGrabMenu.descriptionText = I("yowsa yow yow yow!");
             }
 
             public void Reset(List<Item> newItems)
@@ -255,6 +258,43 @@ namespace NermNermNerm.Junimatic
                 finally
                 {
                     this.owner.OnPlayerChangedShinyList(container.ItemsToGrabMenu.actualInventory.Where(i => i is not null));
+                }
+            }
+
+            public override void draw(SpriteBatch b)
+            {
+                // Mostly copied from StorageContainer
+                b.Draw(Game1.fadeToBlackRect, new Rectangle(0, 0, Game1.uiViewport.Width, Game1.uiViewport.Height), Color.Black * 0.5f);
+
+                // ..except for this call to MenuWithInventory.draw
+                // base.draw(b, drawUpperPortion: false, drawDescriptionArea: false);
+                int red = -1, green = -1, blue = -1;
+                // Copied from 
+                if (this.trashCan != null)
+                {
+                    this.trashCan.draw(b);
+                    b.Draw(Game1.mouseCursors, new Vector2(this.trashCan.bounds.X + 60, this.trashCan.bounds.Y + 40), new Rectangle(564 + Game1.player.trashCanLevel * 18, 129, 18, 10), Color.White, this.trashCanLidRotation, new Vector2(16f, 10f), 4f, SpriteEffects.None, 0.86f);
+                }
+                Game1.drawDialogueBox(this.xPositionOnScreen - IClickableMenu.borderWidth / 2, this.yPositionOnScreen + IClickableMenu.borderWidth + IClickableMenu.spaceToClearTopBorder + 64, this.width, this.height - (IClickableMenu.borderWidth + IClickableMenu.spaceToClearTopBorder + 192), speaker: false, drawOnlyBox: true);
+                this.okButton?.draw(b);
+                this.inventory.draw(b, red, green, blue);
+                // end MenuWithInventory.draw
+                
+
+                Game1.drawDialogueBox(this.ItemsToGrabMenu.xPositionOnScreen - IClickableMenu.borderWidth - IClickableMenu.spaceToClearSideBorder, ItemsToGrabMenu.yPositionOnScreen - IClickableMenu.borderWidth - IClickableMenu.spaceToClearTopBorder, ItemsToGrabMenu.width + IClickableMenu.borderWidth * 2 + IClickableMenu.spaceToClearSideBorder * 2, ItemsToGrabMenu.height + IClickableMenu.spaceToClearTopBorder + IClickableMenu.borderWidth * 2, speaker: false, drawOnlyBox: true);
+                this.ItemsToGrabMenu.draw(b);
+                // this.poof?.draw(b, localPosition: true);
+                if (!this.hoverText.Equals(""))
+                {
+                    drawHoverText(b, this.hoverText, Game1.smallFont);
+                }
+
+                base.heldItem?.drawInMenu(b, new Vector2(Game1.getOldMouseX() + 16, Game1.getOldMouseY() + 16), 1f);
+                this.drawMouse(b);
+                string text = this.ItemsToGrabMenu.descriptionTitle;
+                if (text != null && text.Length > 1)
+                {
+                    drawHoverText(b, this.ItemsToGrabMenu.descriptionTitle, Game1.smallFont, 32 + ((base.heldItem != null) ? 16 : (-21)), 32 + ((base.heldItem != null) ? 16 : (-21)));
                 }
             }
         }

--- a/Junimatic/JunimoStatus.cs
+++ b/Junimatic/JunimoStatus.cs
@@ -1,0 +1,262 @@
+using StardewModdingAPI.Events;
+using StardewModdingAPI;
+using StardewValley;
+using Microsoft.Xna.Framework;
+using StardewValley.Menus;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using System.Linq;
+
+using static NermNermNerm.Stardew.LocalizeFromSource.SdvLocalize;
+
+namespace NermNermNerm.Junimatic
+{
+    public class JunimoStatus : ModLet
+    {
+        public const int NumShinySlots = 10;
+
+        public const string UpdateListMessageId = "Junimatic.ShinyList";
+        public const string AskForListMessageId = "Junimatic.PleaseSendList";
+        private const string ShinyThingsCustomDataName = "Junimatic.ShinyThings";
+
+
+        public override void Entry(ModEntry mod)
+        {
+            base.Entry(mod);
+
+            this.Helper.Events.Input.ButtonPressed += this.Input_ButtonPressed;
+            this.Helper.Events.Multiplayer.ModMessageReceived += this.Multiplayer_ModMessageReceived;
+        }
+
+        private void SendState(string serializedShinyList)
+        {
+            this.Helper.Multiplayer.SendMessage(serializedShinyList, UpdateListMessageId, [this.Mod.ModManifest.UniqueID]);
+        }
+
+        private void SendAskForList()
+        {
+            this.Helper.Multiplayer.SendMessage("", AskForListMessageId, [this.Mod.ModManifest.UniqueID], [Game1.MasterPlayer.UniqueMultiplayerID]);
+        }
+
+        private void Multiplayer_ModMessageReceived(object? sender, ModMessageReceivedEventArgs e)
+        {
+            switch (e.Type)
+            {
+                case UpdateListMessageId:
+                    string serializedShinyList = e.ReadAs<string>();
+                    if (Game1.activeClickableMenu is JunimoStatusMenu menu)
+                    {
+                        menu.Reset(this.DeserializeShinyList(serializedShinyList));
+                    }
+                    if (Game1.IsMasterGame)
+                    {
+                        this.SaveRawShinyList(serializedShinyList);
+                    }
+                    break;
+                case AskForListMessageId:
+                    if (Game1.IsMasterGame) // This should always be true since we only send this message to the master game.
+                    {
+                        this.SendState(this.GetRawShinyList());
+                    }
+                    break;
+                default:
+                    break;
+            };
+        }
+
+        private void Input_ButtonPressed(object? sender, ButtonPressedEventArgs e)
+        {
+            if (e.Button == SButton.MouseRight)
+            {
+                Vector2 tile = this.Helper.Input.GetCursorPosition().GrabTile;
+                var obj = Game1.player?.currentLocation?.getObjectAtTile((int)tile.X, (int)tile.Y);
+                if (obj?.ItemId == UnlockPortal.JunimoPortal)
+                {
+                    this.LogInfoOnce($"Showing the dialog");
+                    this.ShowDialog();
+                }
+            }
+        }
+
+        private void ShowDialog()
+        {
+            Game1.activeClickableMenu = new JunimoStatusMenu(this);
+            if (!Game1.IsMasterGame)
+            {
+                this.SendAskForList();
+            }
+        }
+
+        private string GetRawShinyList() => Game1.CustomData.TryGetValue(ShinyThingsCustomDataName, out string? serialized) ? serialized : "";
+
+        private void SaveRawShinyList(string? serialized)
+        {
+            if (string.IsNullOrEmpty(serialized))
+            {
+                Game1.CustomData.Remove(ShinyThingsCustomDataName);
+            }
+            else
+            {
+                Game1.CustomData[ShinyThingsCustomDataName] = serialized;
+            }
+        }
+
+        private List<Item> LoadShinyThings()
+        {
+            Game1.CustomData.TryGetValue("Junimatic.ShinyThings", out string? serialized);
+            return this.DeserializeShinyList(serialized ?? "");
+        }
+
+        private List<Item> DeserializeShinyList(string serialized)
+        {
+            var itemPattern = new Regex(@"^(?<qiid>.*):(?<quality>\d+)$");
+            List<Item> result = new();
+            foreach (string s in serialized.Split(",", System.StringSplitOptions.RemoveEmptyEntries))
+            {
+                var match = itemPattern.Match(s);
+                Item? item = null;
+                if (match.Success)
+                {
+                    int quality = int.Parse(match.Groups[I("quality")].Value);
+                    string qiid = match.Groups[I("qiid")].Value;
+                    item = ItemRegistry.Create(qiid, 1, quality, true);
+                }
+                if (item is null)
+                {
+                    this.LogWarning($"One of the Junimatic Shiny Things was either not stored correctly or is an item that belongs to a mod that has been removed: '{s}'");
+                }
+                else
+                {
+                    result.Add(item);
+                }
+            }
+            return result;
+        }
+
+        private string SerializeShinyList(IEnumerable<Item> shinyThings)
+        {
+            StringBuilder serialized = new StringBuilder();
+            foreach (var item in shinyThings)
+            {
+                if (serialized.Length > 0)
+                {
+                    serialized.Append(",");
+                }
+                serialized.Append($"{item.QualifiedItemId}:{item.Quality}");
+            }
+            return serialized.ToString();
+        }
+
+        private void OnPlayerChangedShinyList(IEnumerable<Item> shinyThings)
+        {
+            string serialized = this.SerializeShinyList(shinyThings);
+            this.SendState(serialized);
+            if (Game1.IsMasterGame)
+            {
+                this.SaveRawShinyList(serialized);
+            }
+        }
+
+        private class JunimoStatusMenu : StorageContainer
+        {
+            private readonly JunimoStatus owner;
+
+            public JunimoStatusMenu(JunimoStatus owner)
+                : base(FluffUpList(Game1.IsMasterGame ? owner.LoadShinyThings() : new List<Item>()),
+                      NumShinySlots,
+                      2,
+                      (i, p, o, c, ir) => ((JunimoStatusMenu)c).OnChangingShinyItems(i, p, o, c, ir),
+                      Utility.highlightSmallObjects)
+            {
+                this.owner = owner;
+            }
+
+            public void Reset(List<Item> newItems)
+            {
+                for (int i = 0; i < NumShinySlots; ++i)
+                {
+                    this.ItemsToGrabMenu.actualInventory[i] = i < newItems.Count ? newItems[i] : null;
+                }
+            }
+
+            private static List<Item?> FluffUpList(List<Item> plainList)
+            {
+                List<Item?> result = new(plainList);
+                while (result.Count < NumShinySlots)
+                {
+                    result.Add(null);
+                }
+                return result;
+            }
+
+
+            private bool OnChangingShinyItems(Item? i, int position, Item? old, StorageContainer container, bool onRemoval)
+            {
+                // The arguments to this thing are pretty much impossible to name well.
+                //
+                // If the user has an item that they've selected:
+                //  'onRemoval' is false, 'i' is the incoming item and 'old' is null.
+                //
+                // If nothing is selected and the user clicks on an item in the box:
+                //  'onRemoval' is true, 'i' is the item in the chest and 'old' is null.
+                //
+                // If the user has something selected and clicks on an item in the box, two events are generated:
+                //  #1 - 'onRemoval' is true, 'i' is the item in the chest and 'old' is the item the user has selected.
+                //  #2 - 'onRemoval' is false, 'i' is the incoming item, 'old' is the item in the chest.
+                //
+                // Apparently, 'i' is never null.  I'm leaving guards against it in-place.
+                //
+                // The return value indicates whether a sound should be played.
+                //
+                // container.heldItem is the item that is currently being "dragged" in the dialog.
+
+                this.owner.LogInfo($"i={(i is null ? "null" : IF($"{i.Name}:{i.Quality}#{i.Stack}"))} old={(old is null ? "null" : IF($"{old.Name}:{old.Quality}#{old.Stack}"))} onRemoval={onRemoval}");
+                try
+                {
+                    if (!onRemoval && i is not null)
+                    {
+                        if (i.Stack > 1 || (i.Stack == 1 && old != null && old.Stack == 1 && i.canStackWith(old)))
+                        {
+                            // This case covers the first event of the swap operation and the add operations where we have more than one item held
+
+                            if (old != null && old.canStackWith(i)) // something's held and it's the same kind of thing as what's in the chest
+                            {
+                                // This does nothing - the items in the actual inventory are always stack size 1.
+                                container.ItemsToGrabMenu.actualInventory[position].Stack = 1;
+
+                                // This does nothing - when onRemove is false, 'old' is the item in the chest, so container.heldItem already == old
+                                container.heldItem = old;
+                                return false;
+                            }
+
+                            if (old != null)
+                            {
+                                // swaps what's in the hand and what's in the chest.
+                                Utility.addItemToInventory(old, position, container.ItemsToGrabMenu.actualInventory);
+                                container.heldItem = i;
+                                return false;
+                            }
+
+                            // This is the case where you're adding to an empty slot
+                            int allButOne = i.Stack - 1; // The stack size after putting it in the container - can be zero
+                            Item reject = i.getOne(); // 'reject' is the part of the incoming stack that won't fit because we only take one item.
+                            reject.Stack = allButOne; //   <- see that it's the right size
+                            container.heldItem = reject; //  And now that's what's in-hand
+                            i.Stack = 1; // 
+                        }
+                    }
+                    else if (old != null && old.Stack > 1 && !old.Equals(i))
+                    {
+                        return false;
+                    }
+                    return true;
+                }
+                finally
+                {
+                    this.owner.OnPlayerChangedShinyList(container.ItemsToGrabMenu.actualInventory.Where(i => i is not null));
+                }
+            }
+        }
+    }
+}

--- a/Junimatic/JunimoStatusMenu.cs
+++ b/Junimatic/JunimoStatusMenu.cs
@@ -6,6 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using Microsoft.Xna.Framework.Media;
 using StardewValley;
+using StardewValley.BellsAndWhistles;
 using StardewValley.Menus;
 
 using static NermNermNerm.Stardew.LocalizeFromSource.SdvLocalize;
@@ -326,10 +327,9 @@ namespace NermNermNerm.Junimatic
             b.Draw(Game1.fadeToBlackRect, new Rectangle(0, 0, Game1.uiViewport.Width, Game1.uiViewport.Height), Color.Black * 0.5f);
             base.draw(b, drawUpperPortion: false, drawDescriptionArea: false);
 
-            string title = L("* Shiny Things *");
-            var titleSize = Game1.dialogueFont.MeasureString(title);
-            int titleWidth = (int)titleSize.X;
-            int titleHeight = (int)titleSize.Y;
+            string title = L("= $ Shiny things $ =");
+            int titleWidth = SpriteText.getWidthOfString(title);
+            int titleHeight = SpriteText.getHeightOfString(title);
             int titleMargin = titleHeight / 4;
 
             // This is the box that contains the 'Shiny things' title and list of items.
@@ -345,7 +345,7 @@ namespace NermNermNerm.Junimatic
                  +((this.ItemsToGrabMenu.width + IClickableMenu.borderWidth * 2 + IClickableMenu.spaceToClearSideBorder * 2) - titleWidth) / 2,
                 this.ItemsToGrabMenu.yPositionOnScreen - titleMargin - titleHeight
                 );
-            b.DrawString(Game1.dialogueFont, title, titlePosition, Game1.textColor);
+            SpriteText.drawString(b, title, (int)titlePosition.X, (int)titlePosition.Y);
 
             int mouseX = Game1.getOldMouseX();
             int mouseY = Game1.getOldMouseY();

--- a/Junimatic/JunimoStatusMenu.cs
+++ b/Junimatic/JunimoStatusMenu.cs
@@ -1,0 +1,345 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using Microsoft.Xna.Framework.Media;
+using StardewValley;
+using StardewValley.Menus;
+
+using static NermNermNerm.Stardew.LocalizeFromSource.SdvLocalize;
+
+
+namespace NermNermNerm.Junimatic
+{
+    /// <summary>
+    ///   Implements the UI that pops up when you interact with a Junimo Portal.  This is the UI-interaction part,
+    ///   the backing control is in the <see cref="JunimoStatus"/> modlet.
+    /// </summary>
+    /// <remarks>
+    ///   This is an adaptation of the game's <see cref="StorageContainer"/> class.  That class, despite it's general-purpose-sounding
+    ///   name is only used for the Grange Display at the Stardew Valley Fair.  I suspect it was originally built with the idea
+    ///   of being used in more than one place, but when it was tried to use in that way, it was found that it was chok-a-blok
+    ///   full of hard-coding for that use and thus I'm probably not the first one to copy it.
+    /// </remarks>
+    public class JunimoStatusMenu : MenuWithInventory
+    {
+        private TemporaryAnimatedSprite? poof = null;
+        private InventoryMenu ItemsToGrabMenu;
+        private readonly JunimoStatus owner;
+
+        public JunimoStatusMenu(JunimoStatus owner)
+            : base(Utility.highlightSmallObjects, okButton: true, trashCan: true)
+        {
+            this.owner = owner;
+
+            List<Item?> shinyItems = Game1.IsMasterGame ? new List<Item?>(owner.LoadShinyThings()) : new List<Item?>();
+            while (shinyItems.Count < JunimoStatus.NumShinySlots)
+            {
+                shinyItems.Add(null);
+            }
+
+            this.ItemsToGrabMenu = new InventoryMenu(
+                this.inventory.xPositionOnScreen,
+                this.yPositionOnScreen + 192,
+                playerInventory: false,
+                shinyItems, null, JunimoStatus.NumShinySlots, 1);
+            for (int i = 0; i < this.ItemsToGrabMenu.actualInventory.Count; i++)
+            {
+                if (i >= this.ItemsToGrabMenu.actualInventory.Count - this.ItemsToGrabMenu.capacity)
+                {
+                    this.ItemsToGrabMenu.inventory[i].downNeighborID = i + 53910;
+                }
+            }
+
+            for (int j = 0; j < base.inventory.inventory.Count; j++)
+            {
+                base.inventory.inventory[j].myID = j + 53910;
+                if (base.inventory.inventory[j].downNeighborID != -1)
+                {
+                    base.inventory.inventory[j].downNeighborID += 53910;
+                }
+
+                if (base.inventory.inventory[j].rightNeighborID != -1)
+                {
+                    base.inventory.inventory[j].rightNeighborID += 53910;
+                }
+
+                if (base.inventory.inventory[j].leftNeighborID != -1)
+                {
+                    base.inventory.inventory[j].leftNeighborID += 53910;
+                }
+
+                if (base.inventory.inventory[j].upNeighborID != -1)
+                {
+                    base.inventory.inventory[j].upNeighborID += 53910;
+                }
+
+                if (j < 12)
+                {
+                    base.inventory.inventory[j].upNeighborID = this.ItemsToGrabMenu.actualInventory.Count - this.ItemsToGrabMenu.capacity / this.ItemsToGrabMenu.rows;
+                }
+            }
+
+            this.dropItemInvisibleButton.myID = -500;
+            this.ItemsToGrabMenu.dropItemInvisibleButton.myID = -500;
+            if (Game1.options.SnappyMenus)
+            {
+                this.populateClickableComponentList();
+                this.setCurrentlySnappedComponentTo(53910);
+                this.snapCursorToCurrentSnappedComponent();
+            }
+        }
+
+        public override void gameWindowSizeChanged(Rectangle oldBounds, Rectangle newBounds)
+        {
+            base.gameWindowSizeChanged(oldBounds, newBounds);
+            this.ItemsToGrabMenu = new InventoryMenu(
+                this.inventory.xPositionOnScreen,
+                this.yPositionOnScreen + 192,
+                playerInventory: false,
+                this.ItemsToGrabMenu.actualInventory,
+                null, this.ItemsToGrabMenu.capacity, this.ItemsToGrabMenu.rows);
+        }
+
+        public override void receiveLeftClick(int x, int y, bool playSound = true)
+        {
+            Item item = base.heldItem;
+            int num = item?.Stack ?? (-1);
+            if (base.isWithinBounds(x, y))
+            {
+                base.receiveLeftClick(x, y, playSound: false);
+            }
+
+            bool flag = true;
+            if (this.ItemsToGrabMenu.isWithinBounds(x, y))
+            {
+                base.heldItem = this.ItemsToGrabMenu.leftClick(x, y, base.heldItem, playSound: false);
+                if ((base.heldItem != null && item == null) || (base.heldItem != null && item != null && !base.heldItem.Equals(item)))
+                {
+                    flag = this.itemChangeBehavior(base.heldItem, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), item, this, onRemoval: true);
+
+                    if (flag)
+                    {
+                        Game1.playSound("dwop");
+                    }
+                }
+
+                if ((base.heldItem == null && item != null) || (base.heldItem != null && item != null && !base.heldItem.Equals(item)))
+                {
+                    Item? one = base.heldItem;
+                    if (base.heldItem == null && this.ItemsToGrabMenu.getItemAt(x, y) != null && num < this.ItemsToGrabMenu.getItemAt(x, y).Stack)
+                    {
+                        one = item.getOne();
+                        one.Stack = num;
+                    }
+
+                    flag = this.itemChangeBehavior(item, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), one, this, onRemoval: true);
+
+                    if (flag)
+                    {
+                        Game1.playSound("Ship");
+                    }
+                }
+
+                Item? item2 = base.heldItem;
+                if (item2 != null && item2.IsRecipe)
+                {
+                    string key = item2.Name.Substring(0, item2.Name.IndexOf("Recipe") - 1);
+                    try
+                    {
+                        if (item2.Category == -7)
+                        {
+                            Game1.player.cookingRecipes.Add(key, 0);
+                        }
+                        else
+                        {
+                            Game1.player.craftingRecipes.Add(key, 0);
+                        }
+
+                        this.poof = new TemporaryAnimatedSprite("TileSheets\\animations", new Rectangle(0, 320, 64, 64), 50f, 8, 0, new Vector2(x - x % 64 + 16, y - y % 64 + 16), flicker: false, flipped: false);
+                        Game1.playSound("newRecipe");
+                    }
+                    catch (Exception)
+                    {
+                    }
+
+                    base.heldItem = null;
+                }
+                else if (Game1.oldKBState.IsKeyDown(Keys.LeftShift) && Game1.player.addItemToInventoryBool(base.heldItem))
+                {
+                    base.heldItem = null;
+                    flag = this.itemChangeBehavior(base.heldItem, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), item, this, onRemoval: true);
+
+                    if (flag)
+                    {
+                        Game1.playSound("coin");
+                    }
+                }
+            }
+
+            if (this.okButton.containsPoint(x, y) && this.readyToClose())
+            {
+                Game1.playSound("bigDeSelect");
+                Game1.exitActiveMenu();
+            }
+
+            if (this.trashCan.containsPoint(x, y) && base.heldItem != null && base.heldItem.canBeTrashed())
+            {
+                Utility.trashItem(base.heldItem);
+                base.heldItem = null;
+            }
+        }
+
+
+        private bool itemChangeBehavior(Item? i, int position, Item? old, JunimoStatusMenu container, bool onRemoval)
+        {
+            // The arguments to this thing are pretty much impossible to name well.
+            //
+            // If the user has an item that they've selected:
+            //  'onRemoval' is false, 'i' is the incoming item and 'old' is null.
+            //
+            // If nothing is selected and the user clicks on an item in the box:
+            //  'onRemoval' is true, 'i' is the item in the chest and 'old' is null.
+            //
+            // If the user has something selected and clicks on an item in the box, two events are generated:
+            //  #1 - 'onRemoval' is true, 'i' is the item in the chest and 'old' is the item the user has selected.
+            //  #2 - 'onRemoval' is false, 'i' is the incoming item, 'old' is the item in the chest.
+            //
+            // Apparently, 'i' is never null.  I'm leaving guards against it in-place.
+            //
+            // The return value indicates whether a sound should be played.
+            //
+            // container.heldItem is the item that is currently being "dragged" in the dialog.
+
+            this.owner.LogInfo($"i={(i is null ? "null" : IF($"{i.Name}:{i.Quality}#{i.Stack}"))} old={(old is null ? "null" : IF($"{old.Name}:{old.Quality}#{old.Stack}"))} onRemoval={onRemoval}");
+            try
+            {
+                if (!onRemoval && i is not null)
+                {
+                    if (i.Stack > 1 || (i.Stack == 1 && old != null && old.Stack == 1 && i.canStackWith(old)))
+                    {
+                        // This case covers the first event of the swap operation and the add operations where we have more than one item held
+
+                        if (old != null && old.canStackWith(i)) // something's held and it's the same kind of thing as what's in the chest
+                        {
+                            // This does nothing - the items in the actual inventory are always stack size 1.
+                            container.ItemsToGrabMenu.actualInventory[position].Stack = 1;
+
+                            // This does nothing - when onRemove is false, 'old' is the item in the chest, so container.heldItem already == old
+                            container.heldItem = old;
+                            return false;
+                        }
+
+                        if (old != null)
+                        {
+                            // swaps what's in the hand and what's in the chest.
+                            Utility.addItemToInventory(old, position, container.ItemsToGrabMenu.actualInventory);
+                            container.heldItem = i;
+                            return false;
+                        }
+
+                        // This is the case where you're adding to an empty slot
+                        int allButOne = i.Stack - 1; // The stack size after putting it in the container - can be zero
+                        Item reject = i.getOne(); // 'reject' is the part of the incoming stack that won't fit because we only take one item.
+                        reject.Stack = allButOne; //   <- see that it's the right size
+                        container.heldItem = reject; //  And now that's what's in-hand
+                        i.Stack = 1; // 
+                    }
+                }
+                else if (old != null && old.Stack > 1 && !old.Equals(i))
+                {
+                    return false;
+                }
+                return true;
+            }
+            finally
+            {
+                this.owner.OnPlayerChangedShinyList(container.ItemsToGrabMenu.actualInventory.Where(i => i is not null));
+            }
+        }
+
+        public override void receiveRightClick(int x, int y, bool playSound = true)
+        {
+            int num = ((base.heldItem != null) ? base.heldItem.Stack : 0);
+            Item? item = base.heldItem;
+            if (base.isWithinBounds(x, y))
+            {
+                base.receiveRightClick(x, y, playSound: true);
+            }
+
+            if (!this.ItemsToGrabMenu.isWithinBounds(x, y))
+            {
+                return;
+            }
+
+            base.heldItem = this.ItemsToGrabMenu.rightClick(x, y, base.heldItem, playSound: false);
+            if ((base.heldItem != null && item == null) || (base.heldItem != null && item != null && !base.heldItem.Equals(item)) || (base.heldItem != null && item != null && base.heldItem.Equals(item) && base.heldItem.Stack != num))
+            {
+                this.itemChangeBehavior(base.heldItem, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), item, this, onRemoval: true);
+                Game1.playSound("dwop");
+            }
+
+            if ((base.heldItem == null && item != null) || (base.heldItem != null && item != null && !base.heldItem.Equals(item)))
+            {
+                this.itemChangeBehavior(item, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), base.heldItem, this, onRemoval: false);
+                Game1.playSound("Ship");
+            }
+
+            Item? item2 = base.heldItem;
+            if (Game1.oldKBState.IsKeyDown(Keys.LeftShift) && Game1.player.addItemToInventoryBool(base.heldItem))
+            {
+                base.heldItem = null;
+                Game1.playSound("coin");
+                this.itemChangeBehavior(base.heldItem, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), item, this, onRemoval: true);
+            }
+        }
+
+        public override void update(GameTime time)
+        {
+            base.update(time);
+            if (this.poof != null && this.poof.update(time))
+            {
+                this.poof = null;
+            }
+        }
+
+        public override void performHoverAction(int x, int y)
+        {
+            base.performHoverAction(x, y);
+            this.ItemsToGrabMenu.hover(x, y, base.heldItem);
+        }
+
+        public void Reset(List<Item> newItems)
+        {
+            for (int i = 0; i < JunimoStatus.NumShinySlots; ++i)
+            {
+                this.ItemsToGrabMenu.actualInventory[i] = i < newItems.Count ? newItems[i] : null;
+            }
+        }
+
+
+
+        public override void draw(SpriteBatch b)
+        {
+            b.Draw(Game1.fadeToBlackRect, new Rectangle(0, 0, Game1.uiViewport.Width, Game1.uiViewport.Height), Color.Black * 0.5f);
+            base.draw(b, drawUpperPortion: false, drawDescriptionArea: false);
+            Game1.drawDialogueBox(this.ItemsToGrabMenu.xPositionOnScreen - IClickableMenu.borderWidth - IClickableMenu.spaceToClearSideBorder, this.ItemsToGrabMenu.yPositionOnScreen - IClickableMenu.borderWidth - IClickableMenu.spaceToClearTopBorder, this.ItemsToGrabMenu.width + IClickableMenu.borderWidth * 2 + IClickableMenu.spaceToClearSideBorder * 2, this.ItemsToGrabMenu.height + IClickableMenu.spaceToClearTopBorder + IClickableMenu.borderWidth * 2, speaker: false, drawOnlyBox: true);
+            this.ItemsToGrabMenu.draw(b);
+            this.poof?.draw(b, localPosition: true);
+            if (!this.hoverText.Equals(""))
+            {
+                IClickableMenu.drawHoverText(b, this.hoverText, Game1.smallFont);
+            }
+
+            base.heldItem?.drawInMenu(b, new Vector2(Game1.getOldMouseX() + 16, Game1.getOldMouseY() + 16), 1f);
+            this.drawMouse(b);
+            string text = this.ItemsToGrabMenu.descriptionTitle;
+            if (text != null && text.Length > 1)
+            {
+                IClickableMenu.drawHoverText(b, this.ItemsToGrabMenu.descriptionTitle, Game1.smallFont, 32 + ((base.heldItem != null) ? 16 : (-21)), 32 + ((base.heldItem != null) ? 16 : (-21)));
+            }
+        }
+    }
+}

--- a/Junimatic/JunimoStatusMenu.cs
+++ b/Junimatic/JunimoStatusMenu.cs
@@ -118,7 +118,7 @@ namespace NermNermNerm.Junimatic
                 base.heldItem = this.ItemsToGrabMenu.leftClick(x, y, base.heldItem, playSound: false);
                 if ((base.heldItem != null && item == null) || (base.heldItem != null && item != null && !base.heldItem.Equals(item)))
                 {
-                    flag = this.itemChangeBehavior(base.heldItem, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), item, this, onRemoval: true);
+                    flag = this.itemChangeBehavior(base.heldItem, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), item, onRemoval: true);
 
                     if (flag)
                     {
@@ -135,7 +135,7 @@ namespace NermNermNerm.Junimatic
                         one.Stack = num;
                     }
 
-                    flag = this.itemChangeBehavior(item, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), one, this, onRemoval: true);
+                    flag = this.itemChangeBehavior(item, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), one, onRemoval: true);
 
                     if (flag)
                     {
@@ -170,7 +170,7 @@ namespace NermNermNerm.Junimatic
                 else if (Game1.oldKBState.IsKeyDown(Keys.LeftShift) && Game1.player.addItemToInventoryBool(base.heldItem))
                 {
                     base.heldItem = null;
-                    flag = this.itemChangeBehavior(base.heldItem, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), item, this, onRemoval: true);
+                    flag = this.itemChangeBehavior(base.heldItem, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), item, onRemoval: true);
 
                     if (flag)
                     {
@@ -193,7 +193,7 @@ namespace NermNermNerm.Junimatic
         }
 
 
-        private bool itemChangeBehavior(Item? i, int position, Item? old, JunimoStatusMenu container, bool onRemoval)
+        private bool itemChangeBehavior(Item? i, int position, Item? old, bool onRemoval)
         {
             // The arguments to this thing are pretty much impossible to name well.
             //
@@ -225,18 +225,18 @@ namespace NermNermNerm.Junimatic
                         if (old != null && old.canStackWith(i)) // something's held and it's the same kind of thing as what's in the chest
                         {
                             // This does nothing - the items in the actual inventory are always stack size 1.
-                            container.ItemsToGrabMenu.actualInventory[position].Stack = 1;
+                            this.ItemsToGrabMenu.actualInventory[position].Stack = 1;
 
                             // This does nothing - when onRemove is false, 'old' is the item in the chest, so container.heldItem already == old
-                            container.heldItem = old;
+                            this.heldItem = old;
                             return false;
                         }
 
                         if (old != null)
                         {
                             // swaps what's in the hand and what's in the chest.
-                            Utility.addItemToInventory(old, position, container.ItemsToGrabMenu.actualInventory);
-                            container.heldItem = i;
+                            Utility.addItemToInventory(old, position, this.ItemsToGrabMenu.actualInventory);
+                            this.heldItem = i;
                             return false;
                         }
 
@@ -244,7 +244,7 @@ namespace NermNermNerm.Junimatic
                         int allButOne = i.Stack - 1; // The stack size after putting it in the container - can be zero
                         Item reject = i.getOne(); // 'reject' is the part of the incoming stack that won't fit because we only take one item.
                         reject.Stack = allButOne; //   <- see that it's the right size
-                        container.heldItem = reject; //  And now that's what's in-hand
+                        this.heldItem = reject; //  And now that's what's in-hand
                         i.Stack = 1; // 
                     }
                 }
@@ -256,7 +256,7 @@ namespace NermNermNerm.Junimatic
             }
             finally
             {
-                this.owner.OnPlayerChangedShinyList(container.ItemsToGrabMenu.actualInventory.Where(i => i is not null));
+                this.owner.OnPlayerChangedShinyList(this.ItemsToGrabMenu.actualInventory.Where(i => i is not null));
             }
         }
 
@@ -277,13 +277,13 @@ namespace NermNermNerm.Junimatic
             base.heldItem = this.ItemsToGrabMenu.rightClick(x, y, base.heldItem, playSound: false);
             if ((base.heldItem != null && item == null) || (base.heldItem != null && item != null && !base.heldItem.Equals(item)) || (base.heldItem != null && item != null && base.heldItem.Equals(item) && base.heldItem.Stack != num))
             {
-                this.itemChangeBehavior(base.heldItem, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), item, this, onRemoval: true);
+                this.itemChangeBehavior(base.heldItem, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), item, onRemoval: true);
                 Game1.playSound("dwop");
             }
 
             if ((base.heldItem == null && item != null) || (base.heldItem != null && item != null && !base.heldItem.Equals(item)))
             {
-                this.itemChangeBehavior(item, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), base.heldItem, this, onRemoval: false);
+                this.itemChangeBehavior(item, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), base.heldItem, onRemoval: false);
                 Game1.playSound("Ship");
             }
 
@@ -292,7 +292,7 @@ namespace NermNermNerm.Junimatic
             {
                 base.heldItem = null;
                 Game1.playSound("coin");
-                this.itemChangeBehavior(base.heldItem, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), item, this, onRemoval: true);
+                this.itemChangeBehavior(base.heldItem, this.ItemsToGrabMenu.getInventoryPositionOfClick(x, y), item, onRemoval: true);
             }
         }
 
@@ -325,7 +325,31 @@ namespace NermNermNerm.Junimatic
         {
             b.Draw(Game1.fadeToBlackRect, new Rectangle(0, 0, Game1.uiViewport.Width, Game1.uiViewport.Height), Color.Black * 0.5f);
             base.draw(b, drawUpperPortion: false, drawDescriptionArea: false);
-            Game1.drawDialogueBox(this.ItemsToGrabMenu.xPositionOnScreen - IClickableMenu.borderWidth - IClickableMenu.spaceToClearSideBorder, this.ItemsToGrabMenu.yPositionOnScreen - IClickableMenu.borderWidth - IClickableMenu.spaceToClearTopBorder, this.ItemsToGrabMenu.width + IClickableMenu.borderWidth * 2 + IClickableMenu.spaceToClearSideBorder * 2, this.ItemsToGrabMenu.height + IClickableMenu.spaceToClearTopBorder + IClickableMenu.borderWidth * 2, speaker: false, drawOnlyBox: true);
+
+            string title = L("* Shiny Things *");
+            var titleSize = Game1.dialogueFont.MeasureString(title);
+            int titleWidth = (int)titleSize.X;
+            int titleHeight = (int)titleSize.Y;
+            int titleMargin = titleHeight / 4;
+
+            // This is the box that contains the 'Shiny things' title and list of items.
+            Game1.drawDialogueBox(
+                this.ItemsToGrabMenu.xPositionOnScreen - IClickableMenu.borderWidth - IClickableMenu.spaceToClearSideBorder,
+                this.ItemsToGrabMenu.yPositionOnScreen - (IClickableMenu.spaceToClearTopBorder + /*IClickableMenu.borderWidth*/ + titleHeight + titleMargin * 2),
+                this.ItemsToGrabMenu.width + IClickableMenu.borderWidth * 2 + IClickableMenu.spaceToClearSideBorder * 2,
+                this.ItemsToGrabMenu.height + IClickableMenu.spaceToClearTopBorder + IClickableMenu.borderWidth + titleHeight + titleMargin*2,
+                speaker: false, drawOnlyBox: true);
+
+            var titlePosition = new Vector2(
+                this.ItemsToGrabMenu.xPositionOnScreen - IClickableMenu.borderWidth - IClickableMenu.spaceToClearSideBorder
+                 +((this.ItemsToGrabMenu.width + IClickableMenu.borderWidth * 2 + IClickableMenu.spaceToClearSideBorder * 2) - titleWidth) / 2,
+                this.ItemsToGrabMenu.yPositionOnScreen - titleMargin - titleHeight
+                );
+            b.DrawString(Game1.dialogueFont, title, titlePosition, Game1.textColor);
+
+            int mouseX = Game1.getOldMouseX();
+            int mouseY = Game1.getOldMouseY();
+
             this.ItemsToGrabMenu.draw(b);
             this.poof?.draw(b, localPosition: true);
             if (!this.hoverText.Equals(""))
@@ -333,12 +357,18 @@ namespace NermNermNerm.Junimatic
                 IClickableMenu.drawHoverText(b, this.hoverText, Game1.smallFont);
             }
 
-            base.heldItem?.drawInMenu(b, new Vector2(Game1.getOldMouseX() + 16, Game1.getOldMouseY() + 16), 1f);
+            base.heldItem?.drawInMenu(b, new Vector2(mouseX + 16, mouseY + 16), 1f);
             this.drawMouse(b);
             string text = this.ItemsToGrabMenu.descriptionTitle;
             if (text != null && text.Length > 1)
             {
                 IClickableMenu.drawHoverText(b, this.ItemsToGrabMenu.descriptionTitle, Game1.smallFont, 32 + ((base.heldItem != null) ? 16 : (-21)), 32 + ((base.heldItem != null) ? 16 : (-21)));
+            }
+
+            if (mouseX >= titlePosition.X && mouseX <= titlePosition.X + titleWidth
+                && mouseY >= titlePosition.Y && mouseY <= titlePosition.Y + titleHeight)
+            {
+                IClickableMenu.drawHoverText(b, L("Junimos won't put items with equal or better quality\nthan these items into machines or shipping bins."), Game1.smallFont);
             }
         }
     }

--- a/Junimatic/ModEntry.cs
+++ b/Junimatic/ModEntry.cs
@@ -29,6 +29,7 @@ namespace NermNermNerm.Junimatic
         public UnlockAnimal UnlockAnimal = new UnlockAnimal();
         public UnlockForest UnlockForest = new UnlockForest();
         public UnlockFishing UnlockFishing = new UnlockFishing();
+        public JunimoStatusDialog JunimoStatusDialog = new JunimoStatusDialog();
 
         private readonly WorkFinder workFinder = new WorkFinder();
         public PetFindsThings PetFindsThings = new PetFindsThings();
@@ -58,6 +59,7 @@ namespace NermNermNerm.Junimatic
             this.workFinder.Entry(this);
             this.UnlockFishing.Entry(this);
             this.PetFindsThings.Entry(this);
+            this.JunimoStatusDialog.Entry(this);
 
             this.Helper.Events.Content.AssetRequested += this.OnAssetRequested;
 

--- a/Junimatic/ModEntry.cs
+++ b/Junimatic/ModEntry.cs
@@ -29,7 +29,7 @@ namespace NermNermNerm.Junimatic
         public UnlockAnimal UnlockAnimal = new UnlockAnimal();
         public UnlockForest UnlockForest = new UnlockForest();
         public UnlockFishing UnlockFishing = new UnlockFishing();
-        public JunimoStatusDialog JunimoStatusDialog = new JunimoStatusDialog();
+        public JunimoStatus JunimoStatusDialog = new JunimoStatus();
 
         private readonly WorkFinder workFinder = new WorkFinder();
         public PetFindsThings PetFindsThings = new PetFindsThings();

--- a/Junimatic/ModLet.cs
+++ b/Junimatic/ModLet.cs
@@ -1,0 +1,21 @@
+using StardewModdingAPI;
+
+namespace NermNermNerm.Junimatic
+{
+    public class ModLet : ISimpleLog
+    {
+        public virtual void Entry(ModEntry mod)
+        {
+            this.Mod = mod;
+        }
+
+        public ModEntry Mod { get; private set; } = null!;
+
+        public IModHelper Helper => this.Mod.Helper;
+
+        public void WriteToLog(string message, LogLevel level, bool isOnceOnly)
+        {
+            this.Mod.WriteToLog(message, level, isOnceOnly);
+        }
+    }
+}

--- a/Junimatic/ObjectMachine.cs
+++ b/Junimatic/ObjectMachine.cs
@@ -198,7 +198,7 @@ namespace NermNermNerm.Junimatic
                 [StardewValley.Object.buildingResources]
                 ];
 
-            if (machineData.OutputRules is not null)
+            if (machineData?.OutputRules is not null)
             {
                 foreach (var rule in machineData.OutputRules)
                 {

--- a/Junimatic/ObjectMachine.cs
+++ b/Junimatic/ObjectMachine.cs
@@ -130,7 +130,7 @@ namespace NermNermNerm.Junimatic
             var machineData = this.Machine.GetMachineData();
 
             // Mods can specify exactly which Junimo should service it.  That's the top priority.
-            if (machineData.CustomFields?.TryGetValue("Junimatic.JunimoType", out string? modAssignment) == true)
+            if (machineData?.CustomFields?.TryGetValue("Junimatic.JunimoType", out string? modAssignment) == true)
             {
                 if (Enum.TryParse(modAssignment, true, out JunimoType junimoType))
                 {

--- a/Junimatic/ObjectMachine.cs
+++ b/Junimatic/ObjectMachine.cs
@@ -48,7 +48,7 @@ namespace NermNermNerm.Junimatic
         ///   enough stuff in the chest to allow it, it builds a list of the items needed but doesn't
         ///   actually remove the items from the chest.
         /// </summary>
-        public override List<Item>? GetRecipeFromChest(GameStorage storage)
+        public override List<Item>? GetRecipeFromChest(GameStorage storage, Func<Item, bool> isShinyTest)
         {
             if (this.IsManualFeedMachine)
             {
@@ -58,7 +58,8 @@ namespace NermNermNerm.Junimatic
             var machineData = this.Machine.GetMachineData();
             var inputs = new List<Item>();
 
-            var sourceInventory = storage.RawInventory;
+            var sourceInventory = new Inventory();
+            sourceInventory.AddRange(storage.RawInventory.Where(i => !isShinyTest(i)).ToArray());
             // Ensure it has the coal (aka all the 'AdditionalConsumedItems')
             if (machineData.AdditionalConsumedItems is not null)
             {
@@ -89,8 +90,25 @@ namespace NermNermNerm.Junimatic
         ///   Tries to populate the given machine's input with the contents of the chest.  If it
         ///   succeeds, it returns true and the necessary items are removed.
         /// </summary>
-        public override bool FillMachineFromChest(GameStorage storage)
-            => !this.IsManualFeedMachine && this.Machine.AttemptAutoLoad(storage.RawInventory, Game1.MasterPlayer);
+        public override bool FillMachineFromChest(GameStorage storage, Func<Item, bool> isShinyTest)
+        {
+            if (this.IsManualFeedMachine)
+            {
+                return false;
+            }
+
+            // Copied from StardewValley.Object.AttemptAutoLoad, with filtering for items
+            if (this.Machine.heldObject.Value != null)
+            {
+                return false;
+            }
+
+            var rawInventory = storage.RawInventory;
+            StardewValley.Object.autoLoadFrom = rawInventory;
+            bool filledIt = rawInventory.Any(item => !isShinyTest(item) && this.Machine.performObjectDropInAction(item, probe: false, Game1.MasterPlayer));
+            StardewValley.Object.autoLoadFrom = null;
+            return filledIt;
+        }
 
         /// <summary>
         ///   Fills the machine from the supplied Junimo inventory.


### PR DESCRIPTION
Some items are more valuable in their raw form than they are after being processed by a machine (e.g. gold+ quality cloth).  Some items have other uses when they are of high quality (e.g. void eggs for gifting).  This PR adds a dialog box on portals that lets the players add items to designate them as "shiny".  Items in that list with the same or better quality will not be inserted into machines.

Future plans:
* When shipping bins are added to the automation mix, "shiny" things will not be shipped.
* When Junimo Happiness/Efficiency gets implemented, the portal dialog experience will be expanded with UX for showing happiness & workload.