### PR TITLE
Add support for harvesting Garden Pots

### DIFF
--- a/Junimatic/IndoorPotMachine.cs
+++ b/Junimatic/IndoorPotMachine.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework;
+using StardewValley;
+using StardewValley.Characters;
+using StardewValley.Inventories;
+using StardewValley.Objects;
+using StardewValley.TerrainFeatures;
+using SObject = StardewValley.Object;
+
+using static NermNermNerm.Stardew.LocalizeFromSource.SdvLocalize;
+
+namespace NermNermNerm.Junimatic
+{
+    internal class IndoorPotMachine
+        : ObjectMachine 
+    {
+        internal IndoorPotMachine(IndoorPot machine, Point accessPoint)
+            : base(machine, accessPoint)
+        {
+            this.FakeFarmer = new Farmer() {
+                currentLocation = machine.Location,
+                // MARGO throws errors if this isn't set
+                mostRecentlyGrabbedItem = new SObject()
+            };
+
+            this.DummyObject = ItemRegistry.Create<SObject>("770"); // Mixed Seeds dummy object to flag pot ready for harvest
+        }
+
+        public new IndoorPot Machine => (IndoorPot)base.Machine;
+
+        public override bool IsIdle => false; // Only supporting harvesting
+
+        public override SObject? HeldObject => this.GetHeldObject();
+
+        private readonly List<SObject> HarvestObjects = [];
+        private readonly Farmer FakeFarmer;
+        private readonly SObject DummyObject;
+
+        public override bool IsCompatibleWithJunimo(JunimoType projectType)
+        {
+            return projectType == JunimoType.Crops;
+        }
+
+        // 
+        protected override SObject TakeItemFromMachine()
+        {
+            SObject HarvestObject = null!;
+            // Harvest if HarvestObjects is not populated and pot is still ready to harvest
+            if (!this.HarvestObjects.Any() && this.IsHarvestable())
+            {
+                this.Harvest();
+            }
+            // Return and remove the first object in HarvestObjects, if populated
+            if (this.HarvestObjects.Any())
+            {
+                HarvestObject = this.HarvestObjects[0];
+                this.HarvestObjects.RemoveAt(0);
+            }
+            return HarvestObject;
+            
+        }
+
+        /// <summary>
+        /// Return the DummyObject if pot is ready to harvest
+        /// </summary>
+        /// <returns>The DummyObject. Default: null</returns>
+        private SObject? GetHeldObject()
+        {
+            if (this.IsHarvestable()) return this.DummyObject;
+            return null;
+        }
+
+        /// <summary>
+        /// Calculate the harvest objects from the IndoorPot and add them to this.HarvestItems to be collected
+        /// /// </summary>
+        private void Harvest()
+        {
+            // Harvest foragables
+                // While growing, foragables look like any other crop in HoeDirt, data wise.
+                // Once full grown, the foragable is added to the pot's heldObject field and removed from HoeDirt. See Crop.newDay for logic. 
+            if (this.Machine.heldObject.Value != null)
+            {
+                this.HarvestObjects.Add(this.Machine.heldObject.Value);
+                this.Machine.heldObject.Value = null;
+                this.Machine.readyForHarvest.Value = false;
+                return;
+            }
+
+            // Harvest crop from HoeDirt
+            if (this.Machine.hoeDirt.Value is HoeDirt dirt && dirt.crop is not null)
+            {
+                this.HarvestCrop(dirt);
+                return;
+            }
+
+            // Harvest from bush
+            if (this.Machine.bush.Value is Bush bush)
+            {
+                this.HarvestBush(bush);
+            }
+            
+        }
+
+        private void HarvestCrop(HoeDirt dirt)
+        {
+            Crop crop = dirt.crop;
+            int xTile = (int)dirt.Tile.X;
+            int yTile = (int)dirt.Tile.Y;
+
+            // Add the harvested objects to HarvestObjects
+            Patcher.Objects = new Action<SObject>(i => { this.HarvestObjects.Add(i); });
+
+            // Farmer Professions and foraging/farming levels not applied when Junimo harvests
+            Patcher.Harvester = this.FakeFarmer;
+
+            // Harvest crop
+            crop.harvest(xTile, yTile, dirt);
+
+            // Clear patch variables
+            Patcher.Objects = null!;
+            Patcher.Harvester = null!;
+        }
+
+        private void HarvestBush(Bush bush)
+        {
+            Vector2 tileLocation = this.Machine.TileLocation;
+
+            // Add the harvested objects to HarvestObjects
+            Patcher.Objects = new Action<SObject>(i => { this.HarvestObjects.Add(i); });
+
+            // Farmer Professions and foraging/farming levels not applied when Junimo harvests
+            Patcher.Harvester = this.FakeFarmer;
+
+            // Harvest bush
+            // Call Bush.shake to harvest to support custom bushes
+                // Custom Bush has a transpiler on Bush.shake, replacing the call to CreateObjectDebris with a custom method
+                // As a result, Junimatic cannot call CreateObjectDebris directly as that would circumvent the call to the Custom Bush CreateObjectDebris
+                // This Custom Bush method eventually calls the original CreateObjectDebris, which is where the Junimatic prefix would run, adding the items to HarvestObjects
+            bush.shake(tileLocation, doEvenIfStillShaking: false);
+
+            // Clear patch variables
+            Patcher.Objects = null!;
+            Patcher.Harvester = null!;
+        }
+
+        private bool IsHarvestable()
+        {
+            // Check forage
+            if (this.Machine.heldObject.Value != null) return true;
+
+            // Check HoeDirt
+            if (this.Machine.hoeDirt.Value is HoeDirt dirt && dirt.readyForHarvest()) return true;
+
+            // Check Bush
+            if (this.Machine.bush.Value is Bush bush && bush.tileSheetOffset.Value == 1 && bush.inBloom()) return true;
+
+            return false;
+        }
+    }
+}

--- a/Junimatic/Junimatic.csproj
+++ b/Junimatic/Junimatic.csproj
@@ -3,7 +3,8 @@
     <Version>4.16.5</Version>
     <RootNamespace>NermNermNerm.Junimatic</RootNamespace>
 
-    <IgnoreModFilePatterns>\.edits\.json$,new-language-template\.json$</IgnoreModFilePatterns>
+    <IgnoreModFilePatterns>\.edits\.json$,new-language-template\.json$</IgnoreModFilePatterns>    
+    <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Junimatic/Junimatic.csproj
+++ b/Junimatic/Junimatic.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json" HintPath="$(GamePath)\smapi-internal\Newtonsoft.Json.dll" private="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="GameAbstractions\" />
   </ItemGroup>
 </Project>

--- a/Junimatic/ModEntry.cs
+++ b/Junimatic/ModEntry.cs
@@ -10,6 +10,7 @@ using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Characters;
 using StardewValley.GameData.Objects;
+using HarmonyLib;
 
 using static NermNermNerm.Stardew.LocalizeFromSource.SdvLocalize;
 
@@ -58,6 +59,10 @@ namespace NermNermNerm.Junimatic
             this.workFinder.Entry(this);
             this.UnlockFishing.Entry(this);
             this.PetFindsThings.Entry(this);
+
+            // Apply Harmony patches
+            var harmony = new Harmony(this.ModManifest.UniqueID);
+            Patcher.Apply(this, harmony);
 
             this.Helper.Events.Content.AssetRequested += this.OnAssetRequested;
 

--- a/Junimatic/ObjectMachine.cs
+++ b/Junimatic/ObjectMachine.cs
@@ -29,6 +29,10 @@ namespace NermNermNerm.Junimatic
             {
                 return new CrabPotMachine(crabPot, accessPoint);
             }
+            else if(item is IndoorPot indoorPot)
+            {
+                return new IndoorPotMachine(indoorPot, accessPoint);
+            }
             else if (item.GetMachineData() is not null)
             {
                 return new ObjectMachine(item, accessPoint);
@@ -116,7 +120,7 @@ namespace NermNermNerm.Junimatic
             return result;
         }
 
-        private bool IsManualFeedMachine => this.Machine.ItemId == "21"; // Crystalarium
+        private bool IsManualFeedMachine => this.Machine.ItemId == "21" || this.Machine.ItemId == "62"; // Crystalarium or Garden Pot
 
         [NoStrict]
         private bool IsCompatibleWithJunimoNoCache(JunimoType projectType)

--- a/Junimatic/ObjectMachine.cs
+++ b/Junimatic/ObjectMachine.cs
@@ -172,7 +172,7 @@ namespace NermNermNerm.Junimatic
             var machineData = this.Machine.GetMachineData();
 
             // Mods can specify exactly which Junimo should service it.  That's the top priority.
-            if (machineData.CustomFields?.TryGetValue("Junimatic.JunimoType", out string? modAssignment) == true)
+            if (machineData?.CustomFields?.TryGetValue("Junimatic.JunimoType", out string? modAssignment) == true)
             {
                 if (Enum.TryParse(modAssignment, true, out JunimoType junimoType))
                 {

--- a/Junimatic/OutputObjectMetadata.cs
+++ b/Junimatic/OutputObjectMetadata.cs
@@ -17,6 +17,13 @@ namespace NermNermNerm.Junimatic
         public int Quality { get; }
         public Color? TintColor { get; }
 
+        /// <summary>
+        /// Create an OutputObjectMetadata instance from its base fields. Intended for use when constructing from a JsonString.
+        /// </summary>
+        /// <param name="ItemId">Item ID</param>
+        /// <param name="Stack">Item stack</param>
+        /// <param name="Quality">Item quality</param>
+        /// <param name="TintColor">ColoredObject color. Not used for other item types.</param>
         [JsonConstructor]
         public OutputObjectMetadata(string ItemId, int Stack, int Quality, Color? TintColor = null)
         {
@@ -26,6 +33,10 @@ namespace NermNermNerm.Junimatic
             this.TintColor = TintColor;
         }
 
+        /// <summary>
+        /// Create an OutputObjectMetadata instance from an Item instance
+        /// </summary>
+        /// <param name="Item">Item instance</param>
         public OutputObjectMetadata(Item Item)
         {
             this.ItemId = Item.QualifiedItemId;

--- a/Junimatic/OutputObjectMetadata.cs
+++ b/Junimatic/OutputObjectMetadata.cs
@@ -1,0 +1,53 @@
+using Microsoft.Xna.Framework;
+using Newtonsoft.Json;
+using StardewValley;
+using StardewValley.Objects;
+using SObject = StardewValley.Object;
+
+namespace NermNermNerm.Junimatic
+{
+    /// <summary>
+    /// Store the required data to recreate the object/colored object
+    /// Used for storing the object in Machine.modData for object persistence 
+    /// </summary> 
+    internal class OutputObjectMetadata
+    {
+        public string ItemId { get; }
+        public int Stack { get; set; }
+        public int Quality { get; }
+        public Color? TintColor { get; }
+
+        [JsonConstructor]
+        public OutputObjectMetadata(string ItemId, int Stack, int Quality, Color? TintColor = null)
+        {
+            this.ItemId = ItemId;
+            this.Stack = Stack;
+            this.Quality = Quality;
+            this.TintColor = TintColor;
+        }
+
+        public OutputObjectMetadata(Item Item)
+        {
+            this.ItemId = Item.QualifiedItemId;
+            this.Stack = Item.Stack;
+            this.Quality = Item.Quality;
+            if (Item is ColoredObject ColoredObject)
+                this.TintColor = ColoredObject.color.Value;
+        }
+        
+        /// <summary>
+        /// Create a StardewValley.Object or ColoredObject from the metadata
+        /// </summary>
+        /// <returns>The StardewValley.Object</returns>
+        public SObject ConvertToSObject()
+        {
+            // Create ColoredObject if TintColor is populated
+            if (this.TintColor is Color color)
+            {
+                return new ColoredObject(this.ItemId, this.Stack, color){ Quality = this.Quality };
+            }
+            // Otherwise, create StardewValley.Object
+            return ItemRegistry.Create<SObject>(this.ItemId, this.Stack, this.Quality);
+        }
+    }
+}

--- a/Junimatic/Patcher.cs
+++ b/Junimatic/Patcher.cs
@@ -50,7 +50,7 @@ namespace NermNermNerm.Junimatic
         }
 
         // Intercept harvest item creation methods and add to IndoorPotMachine HarvestItems list
-        internal static Action<SObject> Objects = null!;
+        internal static Action<Item> Objects = null!;
 
         internal static bool Farmer_addItemToInventoryBool_Prefix(ref bool __result, Item item)
         {
@@ -59,7 +59,7 @@ namespace NermNermNerm.Junimatic
                 // If Objects tracking variable is not null, this was called by Junimatic
                 if (Objects is not null)
                 {
-                    Objects((SObject)item);
+                    Objects(item);
                     __result = true; // Set the result returned to the code calling addItemToInventoryBool to true to indicate item successfully added
                     return false; // Return false to suppress addItemToInventoryBool from running
                 }
@@ -79,7 +79,7 @@ namespace NermNermNerm.Junimatic
                 // If Objects tracking variable is not null, this was called by Junimatic
                 if (Objects is not null)
                 {
-                    Objects((SObject)item);
+                    Objects(item);
                     __result = null!; // Set the result returned to the code calling createItemDebris to null as no Debris is created (returned result is not used)
                     return false; // Return false to suppress createItemDebris from running
                 }
@@ -99,7 +99,7 @@ namespace NermNermNerm.Junimatic
                 // If Objects tracking variable is not null, this was called by Junimatic
                 if (Objects is not null)
                 {
-                    Objects(ItemRegistry.Create<SObject>(id)); // Create the object from the id passed to Game1.createObjectDebris
+                    Objects(ItemRegistry.Create(id)); // Create the item from the id passed to Game1.createObjectDebris
                     return false; // Return false to suppress createObjectDebris from running
                 }
                 return true; // Return true to run createObjectDebris as this was not called by Junimatic

--- a/Junimatic/Patcher.cs
+++ b/Junimatic/Patcher.cs
@@ -1,0 +1,114 @@
+using System;
+using HarmonyLib;
+using StardewModdingAPI;
+using StardewValley;
+using SObject = StardewValley.Object;
+
+namespace NermNermNerm.Junimatic
+{
+    internal static class Patcher 
+    {
+        private static ModEntry Mod = null!;
+        internal static void Apply(ModEntry mod, Harmony harmony)
+        {
+            Mod = mod;
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Farmer), nameof(Farmer.gainExperience)),
+                prefix: new HarmonyMethod(typeof(Patcher), nameof(Farmer_gainExperience_Prefix))
+            );
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Farmer), nameof(Farmer.addItemToInventoryBool)),
+                prefix: new HarmonyMethod(typeof(Patcher), nameof(Farmer_addItemToInventoryBool_Prefix))
+            );
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Game1), nameof(Game1.createItemDebris)),
+                prefix: new HarmonyMethod(typeof(Patcher), nameof(Game1_createItemDebris_Prefix))
+            );
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Game1), "get_player"),
+                postfix: new HarmonyMethod(typeof(Patcher), nameof(Game1_get_player_Postfix))
+            );
+        }
+
+        // Track fake farmer
+        internal static Farmer Harvester = null!;
+
+        // Swap in fake farmer when Junimatic harvesting from garden pot
+        internal static void Game1_get_player_Postfix(ref Farmer __result) 
+        {
+            // If the fake farmer tracking variable is null, this was not called by Junimatic
+            if (Harvester is null) return;
+            __result = Harvester;
+        }
+
+        // Suppress gainExperience from running if called by Junimatic
+        internal static bool Farmer_gainExperience_Prefix()
+        {
+            // If the fake farmer tracking variable is not null, this was called by Junimatic
+            if (Harvester is not null) return false; // Suppress experience gain
+            return true;
+        }
+
+        // Intercept harvest item creation methods and add to IndoorPotMachine HarvestItems list
+        internal static Action<SObject> Objects = null!;
+
+        internal static bool Farmer_addItemToInventoryBool_Prefix(ref bool __result, Item item)
+        {
+            try
+            {
+                // If Objects tracking variable is not null, this was called by Junimatic
+                if (Objects is not null)
+                {
+                    Objects((SObject)item);
+                    __result = true; // Set the result returned to the code calling addItemToInventoryBool to true to indicate item successfully added
+                    return false; // Return false to suppress addItemToInventoryBool from running
+                }
+                return true; // Return true to run addItemToInventoryBool as this was not called by Junimatic
+            }
+            catch (Exception ex)
+            {
+                Mod.LogError($"Failed in {nameof(Farmer_addItemToInventoryBool_Prefix)}:\n{ex}");
+                return true;
+            }
+        }
+
+        internal static bool Game1_createItemDebris_Prefix(ref Debris __result, Item item)
+        {
+            try
+            {
+                // If Objects tracking variable is not null, this was called by Junimatic
+                if (Objects is not null)
+                {
+                    Objects((SObject)item);
+                    __result = null!; // Set the result returned to the code calling createItemDebris to null as no Debris is created (returned result is not used)
+                    return false; // Return false to suppress createItemDebris from running
+                }
+                return true; // Return true to run createItemDebris as this was not called by Junimatic
+            }
+            catch (Exception ex)
+            {
+                Mod.LogError($"Failed in {nameof(Game1_createItemDebris_Prefix)}:\n{ex}");
+                return true;
+            }
+        }
+
+        internal static bool Game1_createObjectDebris_Prefix(string id)
+        {
+            try
+            {
+                // If Objects tracking variable is not null, this was called by Junimatic
+                if (Objects is not null)
+                {
+                    Objects(ItemRegistry.Create<SObject>(id)); // Create the object from the id passed to Game1.createObjectDebris
+                    return false; // Return false to suppress createObjectDebris from running
+                }
+                return true; // Return true to run createObjectDebris as this was not called by Junimatic
+            }
+            catch (Exception ex)
+            {
+                Mod.LogError($"Failed in {nameof(Game1_createObjectDebris_Prefix)}:\n{ex}");
+                return true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #8 
1. Junimos will harvest forage, crops, and bushes (including custom bushes based on the Custom Bush mod)
2. The Junimos do not gain experience
3. The Junimos do not use the players professions and skills. They default to 0. 
4. Multi yield per harvest crops' (e.g. Coffee plant) first harvested item of the harvest can have a quality above base quality while all remaining items in the harvest will be base quality. At harvest, these items are put in a harvest items list that is stored in the base machine's (garden pot) modData to be retrieved next time the junimo is looking for work (since the Junimatic machine instances seem to be recreated for each work finder action).
- Essentially the logic is to check if there are any objects in the buffer. If not, check if pot is ready for harvest and harvest if it is.
- Sunflowers are another example that can produce multiple types of object: the sunflower and x number of sunflower seeds
6. Objects from multi yield per harvest crops and bushes will stack if item id, quality, and tint color (ColoredObjects) match.
7. To flag a garden pot as ready to harvest, a dummy object (set as mixed seeds for no particular reason) is returned as the Junimatic machine instance's heldObject. Best I could tell, this field was only used for checking if a machine was ready to be emptied, with the actual emptying logic handled by a different method.