### PR TITLE
Use forward slash for ModZipPath

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <ModZipPath>$(SolutionDir)\_releases</ModZipPath>
+    <ModZipPath>$(SolutionDir)/_releases</ModZipPath>
   </PropertyGroup>
 
   <!-- mod build package -->


### PR DESCRIPTION
Backslash can get included in the name on Unix systems and causes issues in VSCode's .NET plugin.

```zsh
> find . -name '*\\*'
./Junimatic/\_releases
```

As far as I'm aware, Windows does accept both forward and backslash for file paths.